### PR TITLE
Update Circle VIewer Setup and Fix Old Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+src/data/CIRCLE_assets/*
+src/data/CIRCLE_movement/*
+
+.vscode
+venv/
+__pycache__/

--- a/setup.md
+++ b/setup.md
@@ -1,0 +1,45 @@
+## Setup Instructions
+
+1. **Download Project Files**
+- [Scence + Subject URDF Files (Circle Assets)](https://circledataset.s3.us-west-2.amazonaws.com/release/CIRCLE_assets.zip)
+- [Motion Trajectories (Circle Movement)](https://circledataset.s3.us-west-2.amazonaws.com/release/CIRCLE_movement.zip)
+
+2. **Create a conda environment**
+
+```bash
+conda create -n circle_dataset python=3.9 -y
+conda activate circle_dataset
+```
+
+3. **Install Habitat Sim**
+
+```bash
+pip install cmake
+conda install habitat-sim -c conda-forge -c aihabitat -y
+```
+
+4. **Install other dependencies**
+
+```bash
+pip install fairmotion --no-deps
+pip install torch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0
+pip install black
+pip install dataclasses
+pip install git+https://github.com/nghorbani/human_body_prior.git@0278cb45180992e4d39ba1a11601f5ecc53ee148
+pip install matplotlib
+pip install PyOpenGL==3.1.0
+pip install pyrender==0.1.39
+pip install scikit-learn
+pip install tqdm
+pip install git+https://github.com/nghorbani/body_visualizer.git@be9cf756f8d1daed870d4c7ad1aa5cc3478a546c
+```
+
+5. **Run circle viewer**
+
+```bash
+python circle_viewer.py \ 
+    --scene 102815835 \
+    --dataset <path_to_circle_assets_folder>/floorplanner.scene_dataset_config.json \
+    --experiment_dir <path_to_circle_movement_folder>/s1/bathroom1_lights_1_bathroom1/0/001_reaching \
+    --urdf <path_to_circle_assets_folder>/subjects/1.urdf
+```

--- a/src/viewer/circle_viewer.py
+++ b/src/viewer/circle_viewer.py
@@ -183,8 +183,8 @@ class MocapInteractiveViewer(HabitatSimInteractiveViewer):
         """
 
         key = event.key
-        pressed = Application.KeyEvent.Key
-        mod = Application.InputEvent.Modifier
+        pressed = Application.Key
+        mod = Application.Modifier
 
         shift_pressed = bool(event.modifiers & mod.SHIFT)
 
@@ -357,12 +357,12 @@ class MocapInteractiveViewer(HabitatSimInteractiveViewer):
         # first person agent
         camera_sensor_spec = habitat_sim.CameraSensorSpec()
         camera_sensor_spec.sensor_type = habitat_sim.SensorType.COLOR
-        camera_sensor_spec.resolution = [
-            self.sim_settings["height"],
-            self.sim_settings["width"],
-        ]
-        camera_sensor_spec.position = np.array([0, 0, 0])
-        camera_sensor_spec.orientation = np.array([0, 0, 0])
+        camera_sensor_spec.resolution = mn.Vector2i(
+            int(self.sim_settings["width"]),
+            int(self.sim_settings["height"]),
+        )
+        camera_sensor_spec.position = mn.Vector3(0, 0, 0)
+        camera_sensor_spec.orientation = mn.Vector3(0, 0, 0)
         camera_sensor_spec.uuid = "fpov_sensor"
 
         agent_config = habitat_sim.agent.AgentConfiguration(

--- a/src/viewer/habitat_viewer.py
+++ b/src/viewer/habitat_viewer.py
@@ -100,7 +100,7 @@ class HabitatSimInteractiveViewer(Application):
         self.cached_urdf = ""
 
         # set up our movement map
-        key = Application.KeyEvent.Key
+        key = Application.Key
         self.pressed = {
             key.UP: False,
             key.DOWN: False,
@@ -115,7 +115,7 @@ class HabitatSimInteractiveViewer(Application):
         }
 
         # set up our movement key bindings map
-        key = Application.KeyEvent.Key
+        key = Application.Key
         self.key_to_action = {
             key.UP: "look_up",
             key.DOWN: "look_down",
@@ -138,7 +138,7 @@ class HabitatSimInteractiveViewer(Application):
         )
 
         # Glyphs we need to render everything
-        self.glyph_cache = text.GlyphCache(mn.Vector2i(256))
+        self.glyph_cache = text.GlyphCacheGL(mn.PixelFormat.R8_UNORM, mn.Vector2i(256))
         self.display_font.fill_glyph_cache(
             self.glyph_cache,
             string.ascii_lowercase
@@ -454,7 +454,7 @@ class HabitatSimInteractiveViewer(Application):
         if repetitions == 0:
             return
 
-        key = Application.KeyEvent.Key
+        key = Application.Key
         agent = self.sim.agents[self.agent_id]
         press: Dict[key.key, bool] = self.pressed
         act: Dict[key.key, str] = self.key_to_action
@@ -484,8 +484,8 @@ class HabitatSimInteractiveViewer(Application):
         key will be set to False for the next `self.move_and_look()` to update the current actions.
         """
         key = event.key
-        pressed = Application.KeyEvent.Key
-        mod = Application.InputEvent.Modifier
+        pressed = Application.Key
+        mod = Application.Modifier
 
         shift_pressed = bool(event.modifiers & mod.SHIFT)
         alt_pressed = bool(event.modifiers & mod.ALT)
@@ -648,13 +648,13 @@ class HabitatSimInteractiveViewer(Application):
         event.accepted = True
         self.redraw()
 
-    def mouse_move_event(self, event: Application.MouseMoveEvent) -> None:
+    def mouse_move_event(self, event: Application.PointerMoveEvent) -> None:
         """
-        Handles `Application.MouseMoveEvent`. When in LOOK mode, enables the left
+        Handles `Application.PointerMoveEvent`. When in LOOK mode, enables the left
         mouse button to steer the agent's facing direction. When in GRAB mode,
         continues to update the grabber's object position with our agents position.
         """
-        button = Application.MouseMoveEvent.Buttons
+        button = Application.PointerMoveEvent.Buttons
         # if interactive mode -> LOOK MODE
         if event.buttons == button.LEFT and self.mouse_interaction == MouseMode.LOOK:
             agent = self.sim.agents[self.agent_id]
@@ -679,12 +679,12 @@ class HabitatSimInteractiveViewer(Application):
         self.redraw()
         event.accepted = True
 
-    def mouse_press_event(self, event: Application.MouseEvent) -> None:
+    def mouse_press_event(self, event: Application.PointerEvent) -> None:
         """
         Handles `Application.MouseEvent`. When in GRAB mode, click on
         objects to drag their position. (right-click for fixed constraints)
         """
-        button = Application.MouseEvent.Button
+        button = Application.PointerEvent.Button
         physics_enabled = self.sim.get_physics_simulation_library()
 
         # if interactive mode is True -> GRAB MODE
@@ -776,7 +776,7 @@ class HabitatSimInteractiveViewer(Application):
         self.redraw()
         event.accepted = True
 
-    def mouse_scroll_event(self, event: Application.MouseScrollEvent) -> None:
+    def mouse_scroll_event(self, event: Application.ScrollEvent) -> None:
         """
         Handles `Application.MouseScrollEvent`. When in LOOK mode, enables camera
         zooming (fine-grained zoom using shift) When in GRAB mode, adjusts the depth
@@ -791,9 +791,9 @@ class HabitatSimInteractiveViewer(Application):
             return
 
         # use shift to scale action response
-        shift_pressed = bool(event.modifiers & Application.InputEvent.Modifier.SHIFT)
-        alt_pressed = bool(event.modifiers & Application.InputEvent.Modifier.ALT)
-        ctrl_pressed = bool(event.modifiers & Application.InputEvent.Modifier.CTRL)
+        shift_pressed = bool(event.modifiers & Application.Modifier.SHIFT)
+        alt_pressed = bool(event.modifiers & Application.Modifier.ALT)
+        ctrl_pressed = bool(event.modifiers & Application.Modifier.CTRL)
 
         # if interactive mode is False -> LOOK MODE
         if self.mouse_interaction == MouseMode.LOOK:
@@ -829,7 +829,7 @@ class HabitatSimInteractiveViewer(Application):
         self.redraw()
         event.accepted = True
 
-    def mouse_release_event(self, event: Application.MouseEvent) -> None:
+    def mouse_release_event(self, event: Application.PointerEvent) -> None:
         """
         Release any existing constraints.
         """


### PR DESCRIPTION
## Summary

The Magnum engine has changed over the years, resulting in many subpackages being relocated or deprecated in favor of newer versions. If you try to set it up as is, you won't be able to run the circle viewer. This PR fixes that. The main changes in magnum that I've also changed here:
- `Application.KeyEvent.Key` --> `Application.Key`
- `Application.InputEvent.Modifier` --> `Application.Modifier`
- `Application.MouseMoveEvent` --> `Application.PointerMoveEvent`
- `Application.MouseEvent` --> `Application.PointerEvent`
- `Application.MouseScrollEvent` --> `Application.ScrollEvent`
- `text.GlyphCache` --> `text.GlyphCacheGL`
- numpy arrays --> native magnum vectors

I've also added a setup markdown file because the setup process is a bit trickier now with many packages being unavailable to download or incompatible with other packages.

I have confirmed that I can run and interact in the circle viewer without any issues (MacOS with an M2 Chip)